### PR TITLE
Fix for Safari issue with history.replace

### DIFF
--- a/src/lib/appState.js
+++ b/src/lib/appState.js
@@ -159,20 +159,7 @@ function makeBBox(cx, cy, w, h) {
 }
 
 function saveBBox(bbox, immediate = false) {
-  if(pendingSave) {
-    clearTimeout(pendingSave);
-    pendingSave = 0;
-  }
-
-  if (immediate) saveReally(bbox);
-  else {
-    pendingSave = setTimeout(() => saveReally(bbox), 300);
-  }
-}
-
-function saveReally(bbox) {
-  pendingSave = 0;
-  var bbox = {
+  bbox = {
     cx: (bbox.minX + bbox.maxX) * 0.5,
     cy: (bbox.minY + bbox.maxY) * 0.5,
     w: (bbox.maxX - bbox.minX),
@@ -181,12 +168,23 @@ function saveReally(bbox) {
 
   if (bbox.w <= 0 || bbox.h <= 0) return;
 
-  qs.set(bbox);
-
   currentState.cx = bbox.cx;
   currentState.cy = bbox.cy;
   currentState.w = bbox.w;
   currentState.h = bbox.h;
+
+  if(pendingSave) {
+    clearTimeout(pendingSave);
+    pendingSave = 0;
+  }
+
+  if (immediate) qs.set(bbox);
+  else {
+    pendingSave = setTimeout(() => {
+      pendingSave = 0;
+      qs.set(bbox);
+    }, 300);
+  }
 }
 
 function getCode() {

--- a/src/lib/scene.js
+++ b/src/lib/scene.js
@@ -437,7 +437,7 @@ export default function initScene(gl) {
   }
 
   function applyBoundingBox(boundingBox) {
-    appState.saveBBox(boundingBox, /* immediate = */ true);
+    appState.saveBBox(boundingBox);
     restoreBBox();
     // a hack to trigger panzoom event
     panzoom.moveBy(0, 0, false);


### PR DESCRIPTION
Fixes #11 

@anvaka let me know if this seems like a good solution to you. I figure the only thing you really need to debounce is the QS update, so I'm isolating that (since applyBoundingBox needs currentState to be updated right away but doesn't care about the QS).