### PR TITLE
resetting particle count in automode with generator source

### DIFF
--- a/src/lib/autoMode.js
+++ b/src/lib/autoMode.js
@@ -74,6 +74,7 @@ function next(options) {
   }
 
   if (source === 'generator') {
+    scene.setParticleCount(10000);
     scene.vectorFieldEditorState.setCode(wrapVectorField(generateFunction()));
   } else if (source === 'presets') {
     if (!incomingPresetsQueue || !incomingPresetsQueue.length) {


### PR DESCRIPTION
With `autosource=both` some of the presets set the particle count very high, and the generator fields don't look so great with such high counts, so I figure it's best to just set it back down to the default when going back to the generator.