### PR TITLE
Fixed broken automode for generator.

### DIFF
--- a/src/lib/autoMode.js
+++ b/src/lib/autoMode.js
@@ -74,7 +74,7 @@ function next(options) {
   }
 
   if (source === 'generator') {
-    scene.setParticleCount(10000);
+    scene.setParticlesCount(10000);
     scene.vectorFieldEditorState.setCode(wrapVectorField(generateFunction()));
   } else if (source === 'presets') {
     if (!incomingPresetsQueue || !incomingPresetsQueue.length) {


### PR DESCRIPTION
I just realized auto mode is throwing an exception whenever it uses the generator. I have no idea how we ended up with the wrong function name there, but I've fixed it now.